### PR TITLE
fix: Prevent cleanup if media recorder is still active

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -479,6 +479,9 @@ export default function useAudioRecorder(
 
   useEffect(() => {
     return () => {
+      if (mediaRecorder?.state !== "inactive") {
+        return;
+      }
       if (timer) {
         clearInterval(timer);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -491,7 +491,7 @@ export default function useAudioRecorder(
         clearTimeout(volumeTimerRef.current);
       }
 
-      if (audioContextRef.current) {
+      if (audioContextRef.current  && audioContextRef.current.state !== "closed") {
         audioContextRef.current.close().catch(console.error);
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,7 @@ export default function useAudioRecorder(
         // Set up volume metering using AudioContext
         try {
           // Create audio context
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           const audioContext = new (window.AudioContext ||
             // @ts-expect-error - webkitAudioContext for Safari
             window.webkitAudioContext)();
@@ -194,7 +195,6 @@ export default function useAudioRecorder(
           const dataArray = new Uint8Array(analyser.frequencyBinCount);
 
           const updateVolume = () => {
-            if (!analyser) return;
 
             analyser.getByteFrequencyData(dataArray);
 
@@ -287,6 +287,8 @@ export default function useAudioRecorder(
     timer,
     cleanupAudioUrl,
     audioConstraints,
+    audioBitsPerSecond,
+    browserCompatibility.isSupported,
     chunkInterval,
     onNotSupported,
     volumeMeterRefreshRate,
@@ -466,6 +468,7 @@ export default function useAudioRecorder(
         }
 
         // Apply the new effect
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (audioContextRef.current && mediaSourceRef.current) {
           const { destination } = audioContextRef.current;
           applyAudioEffect(audioContextRef.current, mediaSourceRef.current, destination, effect);
@@ -482,6 +485,7 @@ export default function useAudioRecorder(
       if (mediaRecorder?.state !== "inactive") {
         return;
       }
+
       if (timer) {
         clearInterval(timer);
       }
@@ -498,7 +502,7 @@ export default function useAudioRecorder(
       stopMediaStream(mediaStream);
       cleanupAudioUrl();
     };
-  }, [mediaStream, stopMediaStream, timer, cleanupAudioUrl]);
+  }, [mediaStream, stopMediaStream, timer, cleanupAudioUrl, mediaRecorder]);
 
   return {
     startRecording,

--- a/src/utils/browserSupport.ts
+++ b/src/utils/browserSupport.ts
@@ -45,7 +45,7 @@ export function isMimeTypeSupported(mimeType: string): boolean {
 export function isIOS(): boolean {
   if (typeof navigator === 'undefined') return false;
 
-  return /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream; // Excludes IE11
+  return /iPad|iPhone|iPod/.test(navigator.userAgent) && !('MSStream' in window); // Excludes IE11
 }
 
 /**


### PR DESCRIPTION
Closes #3 by checking if the media recorder is inactive before cleanup.